### PR TITLE
Move by default to python3 and systemd with many fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
 * update burpui-agent to 0.6.5 (Fix: sync pkgs requirements with burp-ui's `#300 <https://git.ziirish.me/ziirish/burp-ui/issues/300>`__)
 * Update python3 to python3.6 on Redhat/Centos
 * Move default installation to python3
+* Support bui-celery to systemd
+* Move default to systemd
 
 v1.6.0:
   * changes to be compatible with burpui 0.6.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
-1.6.1:
+1.7.0:
 
-* update burpui-agent to 0.6.4 (Fix: sync pkgs requirements with burp-ui's `#300 <https://git.ziirish.me/ziirish/burp-ui/issues/300>`__)
+* update burpui-agent to 0.6.5 (Fix: sync pkgs requirements with burp-ui's `#300 <https://git.ziirish.me/ziirish/burp-ui/issues/300>`__)
 * Update python3 to python3.6 on Redhat/Centos
 * Move default installation to python3
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 1.7.0:
 
-* update burpui-agent to 0.6.5 (Fix: sync pkgs requirements with burp-ui's `#300 <https://git.ziirish.me/ziirish/burp-ui/issues/300>`__)
+* keep burpui-agent to 0.6.1 as: can't migrate to 0.6.5 until upgrade burp to 2.2.12+
 * Update python3 to python3.6 on Redhat/Centos
 * Move default installation to python3
 * Support bui-celery to systemd

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.6.1:
+  * Update to burpui 0.6.3
 v1.6.0:
   * changes to be compatible with burpui 0.6.1
   * Removed deprecated config lines

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ So to restart installed services/daemons you should use:
 
     sudo supervisorctl restart bui-celery  (depends on the service you want to restart)
 
-you can also use supervisorctl shell: 
+you can also use supervisorctl shell:
 
     sudo supervisorctl
 
-And then interactively use all options. 
+And then interactively use all options.
 
-*Logs:* 
+*Logs:*
 
 Also supervisord allow proper stdout and stderror to logs redirection, so all logs are under `/var/logs/supervisor`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ burpui_pip_packages:
   - { name: "{{ burpui_pip_burpui }}[gunicorn-extra]", version: "{{ burpui_version }}" }
   - { name: "{{ burpui_pip_burpui }}[celery]", version: "{{ burpui_version }}" }
   - { name: "{{ burpui_pip_burpui }}[websocket]", version: "{{ burpui_version }}" }
-  
+
 burpui_pip_present:
   - "redis"
   - "Flask-Session"
@@ -139,7 +139,7 @@ burpui_agents:
 burpui_sv_priority: "20"
 burpui_sv_directory: "/tmp"
 burpui_sv_environment: "C_FORCE_ROOT=true"
-burpui_sv_command: "bui-celery -c /etc/burp/burpui.cfg -- --beat"
+burpui_sv_command: "/usr/local/bin/bui-celery -c /etc/burp/burpui.cfg -- --beat"
 burpui_sv_autostart: "true"
 burpui_sv_autorestart: "true"
 burpui_sv_stdout_logfile: "/var/log/supervisor/%(program_name)s.log"
@@ -151,6 +151,6 @@ burpui_user: 'root'  # for now only root will work until we handle the creation 
 burpui_group: 'root'
 # gunicorn_systemd_service enables gunicorn.yml to manually setup systemd service instead of using Debian based package
 # It is set True always for RedHat based and Ubuntu equal or major to 16.04
-gunicorn_systemd_service: False
-
+gunicorn_systemd_service: True
+bui_use_systemd: True
 gunicorn_upstart_service: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ burpui_version_dev: master
 burpui_use_dev: False
 
 burpui_pip_burpui: "burp-ui"
-burpui_version: 0.6.4
+burpui_version: 0.6.5
 python_pip_executable: "pip3" # options pip3 / pip2
 
 burpui_pip_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ burpui_version_dev: master
 burpui_use_dev: False
 
 burpui_pip_burpui: "burp-ui"
-burpui_version: 0.6.1
+burpui_version: 0.6.3
 python_pip_executable: "pip2" # options pip3 / pip2
 
 burpui_pip_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ burpui_version_dev: master
 burpui_use_dev: False
 
 burpui_pip_burpui: "burp-ui"
-burpui_version: 0.6.5
+burpui_version: 0.6.1 # can't migrate to 0.6.5 until upgrade burp to 2.2.12+
 python_pip_executable: "pip3" # options pip3 / pip2
 
 burpui_pip_packages:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,0 @@
-
-- src: CoffeeITWorks.burp2_server
-  name: ansible_burp2_server
-  version: v1.11

--- a/run_local_molecule.sh
+++ b/run_local_molecule.sh
@@ -1,0 +1,7 @@
+# https://molecule.readthedocs.io/en/latest/examples.html#docker
+docker run --rm -it --privileged=True \
+    -v "$(pwd)":/tmp/$(basename "${PWD}"):ro \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -w /tmp/$(basename "${PWD}") \
+    retr0h/molecule:latest \
+    sudo molecule test

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -26,7 +26,7 @@
   when: ansible_distribution != "Fedora" and python_pip_executable == 'pip3'
 
 - name: redhat | ensure pip3 command setup is done
-  shell:
+  easy_install:
     name: pip
     state: present
     executable: easy_install-3.6

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -15,19 +15,3 @@
   retries: 3
   delay: 2
   when: ansible_distribution == 'CentOS'
-
-- name: redhat | set pip3 packages for redhat and centos
-  set_fact:
-    burp_agent_py3_packages:
-      - python36
-      - python36-devel
-      - python36-setuptools
-      - redhat-rpm-config
-  when: ansible_distribution != "Fedora" and python_pip_executable == 'pip3'
-
-- name: redhat | ensure pip3 command setup is done
-  easy_install:
-    name: pip
-    state: present
-    executable: easy_install-3.6
-  when: ansible_distribution != "Fedora" and python_pip_executable == 'pip3'

--- a/tasks/bui-celery.yml
+++ b/tasks/bui-celery.yml
@@ -1,56 +1,13 @@
 ---
 # file defaults/bui-celery.yml
 
-- name: install Supervisor
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ burp_ui_celery_dependencies }}"
-
 - name: create burp ui folder
   file:
     path: /var/spool/burpui
     state: directory
 
-- name: configure supervisor logrotate
-  template:
-    src: supervisor_logrotate.j2
-    dest: /etc/logrotate.d/supervisor
+- include_tasks: supervisor.yml
+  when: not bui_use_systemd
 
-# On centos 6 there is no include section by default
-- name: supervisor | configure supervisor settings
-  template:
-    src: redhat_supervisord.conf.j2
-    dest: /etc/supervisord.conf
-  when: ansible_os_family == "RedHat"
-
-# On centos 6 this directory is not created by rpm package
-- name: supervisor | Ensure "{{ supervisoretc_dir }}" dir exists
-  file:
-    path: "{{ supervisoretc_dir }}"
-    state: "directory"
-
-- name: configure bui-celery supervisord service
-  template:
-    src: bui-celery.conf_supervisor.j2
-    dest: "{{ supervisoretc_dir }}/bui-celery.{{ supervisor_ext }}"
-  notify: restart bui-celery
-  register: burpui_celery_service_conf
-
-- name: ensure supervisor is started
-  service:
-    name: "{{ supervisor_service }}"
-    state: started
-    sleep: 4
-
-- name: ensure supervisor is restarted
-  service:
-    name: "{{ supervisor_service }}"
-    state: restarted
-    sleep: 4
-  when: burpui_celery_service_conf.changed
-
-- name: ensure supervisor is enabled
-  service:
-    name: "{{ supervisor_service }}"
-    enabled: yes
+- include_tasks: systemd.yml
+  when: bui_use_systemd

--- a/tasks/bui-upgrade.yml
+++ b/tasks/bui-upgrade.yml
@@ -15,6 +15,5 @@
 #  environment: 
 #    C_FORCE_ROOT: "True"
 
-
 # Restart services
 - meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,44 +27,11 @@
     gunicorn_systemd_service: True
   when: ansible_os_family == 'RedHat'
 
-- name: check only if burpui is installed
-  pip:
-    name: "{{ burpui_pip_burpui }}"
-    state: present
-    executable: "{{ python_pip_executable }}"
-  register: burpui_installed_check
-  check_mode: yes
+- include_tasks: python3_pip.yml
+  when: python_pip_executable == "pip3"
 
-- name: install role packages
-  package:
-    name: "{{ burpui_packages| join(',') }}"
-    state: present
-
-- name: Uninstall burpui pip2 packages when using pip3 as pip executable
-  pip:
-    name: "{{ item.name }}"
-    state: absent
-    version: "{{ item.version}}"
-    executable: "pip2"
-  when: python_pip_executable == "pip3"  
-  with_items: "{{ burpui_pip_packages }}"
-
-- name: install pip packages
-  pip:
-    name: "{{ item }}"
-    state: present
-    executable: "{{ python_pip_executable }}"
-  with_items: "{{ burpui_pip_present }}"
-
-- name: Install pip packages by version
-  pip:
-    name: "{{ item.name }}"
-    state: present
-    version: "{{ item.version}}"
-    executable: "{{ python_pip_executable }}"
-  with_items: "{{ burpui_pip_packages }}"
-  register: bui_pip_install
-  notify: restart burpui services
+- include_tasks: python2_pip.yml
+  when: python_pip_executable == "pip2"
 
 - name: create burp folder
   file:

--- a/tasks/python2_pip.yml
+++ b/tasks/python2_pip.yml
@@ -1,0 +1,26 @@
+---
+
+- name: pip2 | check only if burpui is installed
+  pip:
+    name: "{{ burpui_pip_burpui }}"
+    state: present
+    executable: "{{ python_pip_executable }}"
+  register: burpui_installed_check
+  check_mode: yes
+
+- name: install pip packages
+  pip:
+    name: "{{ item }}"
+    state: present
+    executable: "{{ python_pip_executable }}"
+  with_items: "{{ burpui_pip_present }}"
+
+- name: Install pip packages by version
+  pip:
+    name: "{{ item.name }}"
+    state: present
+    version: "{{ item.version}}"
+    executable: "{{ python_pip_executable }}"
+  with_items: "{{ burpui_pip_packages }}"
+  register: bui_pip_install
+  notify: restart burpui services

--- a/tasks/python2_pip.yml
+++ b/tasks/python2_pip.yml
@@ -8,14 +8,14 @@
   register: burpui_installed_check
   check_mode: yes
 
-- name: install pip packages
+- name: pip2 | install pip packages
   pip:
     name: "{{ item }}"
     state: present
     executable: "{{ python_pip_executable }}"
   with_items: "{{ burpui_pip_present }}"
 
-- name: Install pip packages by version
+- name: pip2 | Install pip packages by version
   pip:
     name: "{{ item.name }}"
     state: present

--- a/tasks/python3_pip.yml
+++ b/tasks/python3_pip.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: pip2 | check only if burpui is installed
+- name: pip3 | check only if burpui is installed
   pip:
     name: "{{ burpui_pip_burpui }}"
     state: present
@@ -8,22 +8,14 @@
   register: burpui_installed_check
   check_mode: yes
 
-- name: Uninstall burpui pip2 packages when using pip3 as pip executable
-  pip:
-    name: "{{ item.name }}"
-    state: absent
-    version: "{{ item.version}}"
-    executable: "pip"
-  with_items: "{{ burpui_pip_packages }}"
-
-- name: install pip packages
+- name: pip3 | install pip packages
   pip:
     name: "{{ item }}"
     state: present
     executable: "{{ python3_pip }}"
   with_items: "{{ burpui_pip_present }}"
 
-- name: Install pip packages by version
+- name: pip3 | Install pip packages by version
   pip:
     name: "{{ item.name }}"
     state: present

--- a/tasks/python3_pip.yml
+++ b/tasks/python3_pip.yml
@@ -1,0 +1,34 @@
+---
+
+- name: pip2 | check only if burpui is installed
+  pip:
+    name: "{{ burpui_pip_burpui }}"
+    state: present
+    executable: "{{ python3_pip }}"
+  register: burpui_installed_check
+  check_mode: yes
+
+- name: Uninstall burpui pip2 packages when using pip3 as pip executable
+  pip:
+    name: "{{ item.name }}"
+    state: absent
+    version: "{{ item.version}}"
+    executable: "pip2"
+  with_items: "{{ burpui_pip_packages }}"
+
+- name: install pip packages
+  pip:
+    name: "{{ item }}"
+    state: present
+    executable: "{{ python3_pip }}"
+  with_items: "{{ burpui_pip_present }}"
+
+- name: Install pip packages by version
+  pip:
+    name: "{{ item.name }}"
+    state: present
+    version: "{{ item.version}}"
+    executable: "{{ python3_pip }}"
+  with_items: "{{ burpui_pip_packages }}"
+  register: bui_pip_install
+  notify: restart burpui services

--- a/tasks/python3_pip.yml
+++ b/tasks/python3_pip.yml
@@ -13,7 +13,7 @@
     name: "{{ item.name }}"
     state: absent
     version: "{{ item.version}}"
-    executable: "pip2"
+    executable: "pip"
   with_items: "{{ burpui_pip_packages }}"
 
 - name: install pip packages

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -24,3 +24,13 @@
   package:
     name: "{{ burpui_packages| join(',') }}"
     state: present
+
+- name: register /usr/local/sbin/burp path
+  stat: 
+    path: "/usr/local/sbin/burp"
+  register: burp_local_sbin_path
+
+- name: change burp path var burpui_backend_burpbin
+  set_fact:
+    burpui_backend_burpbin: /usr/local/sbin/burp
+  when: burp_local_sbin_path.stat.exists

--- a/tasks/requirements.yml
+++ b/tasks/requirements.yml
@@ -12,25 +12,15 @@
   package:
     name: "{{ burpui_system_requirements | join(',') }}"
     state: present
-
-# workaround for ubuntu 14.04 with missing pip3 executable
-- block:
-    
-    - name: stat to see if pip3 executable is present
-      stat:
-        path: '/usr/bin/pip3'
-      register: pip3_executable_stat
-    
-    - name: Absent python3-pip if /usr/bin/pip3 is not present
-      package:
-        name: 'python3-pip'
-        state: absent
-      when: not pip3_executable_stat.stat.exists
-  
-  when: ansible_distribution_release == 'trusty' and python_pip_executable == 'pip3'
+  when: python_pip_executable != "pip3"
 
 - name: install burpui package requirements for python3
   package:
     name: "{{ burpui_py3_packages| join(',') }}"
     state: present
   when: python_pip_executable == "pip3"
+
+- name: install role packages
+  package:
+    name: "{{ burpui_packages| join(',') }}"
+    state: present

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -1,0 +1,50 @@
+---
+
+- name: install Supervisor
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ burp_ui_celery_dependencies }}"
+
+- name: configure supervisor logrotate
+  template:
+    src: supervisor_logrotate.j2
+    dest: /etc/logrotate.d/supervisor
+
+# On centos 6 there is no include section by default
+- name: supervisor | configure supervisor settings
+  template:
+    src: redhat_supervisord.conf.j2
+    dest: /etc/supervisord.conf
+  when: ansible_os_family == "RedHat"
+
+# On centos 6 this directory is not created by rpm package
+- name: supervisor | Ensure "{{ supervisoretc_dir }}" dir exists
+  file:
+    path: "{{ supervisoretc_dir }}"
+    state: "directory"
+
+- name: configure bui-celery supervisord service
+  template:
+    src: bui-celery.conf_supervisor.j2
+    dest: "{{ supervisoretc_dir }}/bui-celery.{{ supervisor_ext }}"
+  notify: restart bui-celery
+  register: burpui_celery_service_conf
+
+- name: ensure supervisor is started
+  service:
+    name: "{{ supervisor_service }}"
+    state: started
+    sleep: 4
+
+- name: ensure supervisor is restarted
+  service:
+    name: "{{ supervisor_service }}"
+    state: restarted
+    sleep: 4
+  when: burpui_celery_service_conf.changed
+
+- name: ensure supervisor is enabled
+  service:
+    name: "{{ supervisor_service }}"
+    enabled: yes

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -1,0 +1,28 @@
+---
+# Setup systemd service
+# Only used when not using supervisord
+
+# burpui-agent
+- name: systemd | configure systemd service for bui-celery
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - { src: "systemd/bui-celery.service.j2",
+        dest: "/etc/systemd/system/bui-celery.service" }
+#  notify:
+#    - systemd daemon-reload
+
+- name: systemd daemon-reload
+  systemd:
+    daemon_reload: yes
+
+- name: systemd | enable bui-celery service
+  systemd:
+    daemon-reload: yes
+    name: bui-celery
+    state: started
+    enabled: yes
+
+- name: flush handlers
+  meta: flush_handlers

--- a/templates/systemd/bui-celery.service.j2
+++ b/templates/systemd/bui-celery.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Burp-UI agent service
+After=network.target
+
+[Service]
+ExecStart={{ burpui_sv_command }}
+User={{ burpui_user }}
+Group={{ burpui_group }}
+Environment={{ burpui_sv_environment }}
+RestartSec=1
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -15,6 +15,10 @@ burpui_py3_packages:
   - python3
   - python3-dev
   - python3-pip
+  - libssl-dev # dependecy of ndg-httpsclient
+  - libffi-dev # dependency for cffi
+  - locales # required for python3
+  - gcc
 
 burpui_packages:
   - redis-server
@@ -23,6 +27,7 @@ burpui_packages:
 burp_ui_celery_dependencies:
   - supervisor
 
+python3_pip: 'pip3'
 supervisoretc_dir: "/etc/supervisor/conf.d"
 supervisor_ext: "conf"
 supervisor_service: supervisor

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -21,10 +21,14 @@ burpui_py3_packages:
   - python3-pip
   - python3-setuptools
   - redhat-rpm-config
+  - openssl-devel
+  - libffi-devel
+  - gcc
 
 burp_ui_celery_dependencies:
   - supervisor
 
+python3_pip: 'pip3'
 supervisoretc_dir: "/etc/supervisor/conf.d"
 supervisor_ext: "conf"
 supervisor_service: supervisord

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -19,11 +19,16 @@ burpui_py3_packages:
   - python36
   - python36-devel
   - python36-setuptools
+  - python36-pip
   - redhat-rpm-config
+  - openssl-devel
+  - libffi-devel
+  - gcc
 
 burp_ui_celery_dependencies:
   - supervisor
 
+python3_pip: 'pip3.6'
 supervisoretc_dir: "/etc/supervisor/conf.d"
 supervisor_ext: "conf"
 supervisor_service: supervisord

--- a/vars/Ubuntu-14.04.yml
+++ b/vars/Ubuntu-14.04.yml
@@ -14,6 +14,10 @@ burpui_py3_packages:
   - python3
   - python3-dev
   - python3-pip
+  - libssl-dev # dependecy of ndg-httpsclient
+  - libffi-dev # dependency for cffi
+  - locales # required for python3
+  - gcc
 
 burpui_packages:
   - redis-server
@@ -22,6 +26,7 @@ burpui_packages:
 burp_ui_celery_dependencies:
   - supervisor
 
+python3_pip: 'pip3'
 supervisoretc_dir: "/etc/supervisor/conf.d"
 supervisor_ext: "conf"
 supervisor_service: supervisor


### PR DESCRIPTION
* keep burpui-agent to 0.6.1 as: can't migrate to 0.6.5 until upgrade burp to 2.2.12+
* Update python3 to python3.6 on Redhat/Centos
* Move default installation to python3
* Support bui-celery to systemd
* Move default to systemd